### PR TITLE
Removed unsave unwrap() methodes (and also formated the code)

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,5 +1,10 @@
 extern crate machine_ip;
 
 fn main() {
-    println!("{}", machine_ip::get().expect("Could not find local IP address.").to_string());
+    println!(
+        "{}",
+        machine_ip::get()
+            .expect("Could not find local IP address.")
+            .to_string()
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,39 @@
-use std::process::Command;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::process::Command;
 
 pub fn get() -> Option<IpAddr> {
-    let output = Command::new("hostname")
-        .args(&["-I"])
-        .output()
-        .expect("failed to execute `hostname`");
+    let output = match Command::new("hostname").args(&["-I"]).output() {
+        Ok(ok) => ok,
+        Err(_) => {
+            return None;
+        }
+    };
 
-    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stdout = match String::from_utf8(output.stdout) {
+        Ok(ok) => ok,
+        Err(_) => {
+            return None;
+        }
+    };
+
     let ips: Vec<&str> = stdout.trim().split(" ").collect::<Vec<&str>>();
     let first = ips.first();
-    match first{
-        Some(first) =>  {
-            if !first.is_empty(){
+    match first {
+        Some(first) => {
+            if !first.is_empty() {
                 if let Ok(addr) = first.parse::<Ipv4Addr>() {
-                    return Some(IpAddr::V4(addr))
-                }
-                else if let Ok(addr) = first.parse::<Ipv6Addr>() {
-                    return Some(IpAddr::V6(addr))
-                }
-                else{
+                    return Some(IpAddr::V4(addr));
+                } else if let Ok(addr) = first.parse::<Ipv6Addr>() {
+                    return Some(IpAddr::V6(addr));
+                } else {
                     None
                 }
-            }else{
+            } else {
                 None
             }
         }
-        None => None
+        None => None,
     }
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The code had one `expect` and one `unwrap` methode, these cause the
program to panic. In most application you do not want the application to
panic, but just handle the errors. This is why I removed those code
parts and replaced it with a `match`. Since the function already
returned an `Option` Type I made the `match` condition to exit the
function with `None`. For example, with these changes the application 
does not panic if it can't find/execute the `hostname -I` command.

I also formatted the code with `rustfmt` to match the official rust
style guidelines.

